### PR TITLE
fix: lagt til pseudostatus KJOERT som brukes ved kjøring. 

### DIFF
--- a/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjeneste.java
+++ b/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjeneste.java
@@ -140,7 +140,7 @@ public class ProsessTaskApplikasjonTjeneste {
 
     private void validerBetingelserForRestart(Long prosessTaskId, String nåværendeStatus, ProsessTaskData ptd) {
         if (ptd != null) {
-            if (ptd.getStatus().equals(ProsessTaskStatus.FERDIG)) {
+            if (ptd.getStatus().equals(ProsessTaskStatus.FERDIG) || ptd.getStatus().equals(ProsessTaskStatus.KJOERT)) {
                 throw ProsessTaskRestTjenesteFeil.FACTORY.kanIkkeRestarteEnFerdigKjørtProsesstask(prosessTaskId).toException();
             }
             if (!ProsessTaskStatus.KLAR.equals(ptd.getStatus()) && (nåværendeStatus == null || !ptd.getStatus().equals(ProsessTaskStatus.valueOf(nåværendeStatus)))) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskStatus.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskStatus.java
@@ -3,6 +3,7 @@ package no.nav.vedtak.felles.prosesstask.api;
 public enum ProsessTaskStatus {
 
     KLAR("KLAR"), //$NON-NLS-1$
+    KJOERT("KJOERT"),
     FERDIG("FERDIG"), //$NON-NLS-1$
     VENTER_SVAR("VENTER_SVAR"), //$NON-NLS-1$
     VETO("VETO"), //$NON-NLS-1$

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/HandleProsessTaskLifecycleObserver.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/HandleProsessTaskLifecycleObserver.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.spi.CDI;
+import javax.inject.Inject;
 
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
@@ -18,6 +19,7 @@ public class HandleProsessTaskLifecycleObserver {
 
     private final List<ProsessTaskLifecycleObserver> lifecycleObservers = new ArrayList<>();
 
+    @Inject
     public HandleProsessTaskLifecycleObserver() {
         // for CDI proxies
         for (ProsessTaskLifecycleObserver obs : CDI.current().select(ProsessTaskLifecycleObserver.class)) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskEventPubliserer.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskEventPubliserer.java
@@ -26,10 +26,10 @@ public class ProsessTaskEventPubliserer {
     }
 
     @Inject
-    public ProsessTaskEventPubliserer(Event<ProsessTaskEvent> publiserer) {
+    public ProsessTaskEventPubliserer(Event<ProsessTaskEvent> publiserer, HandleProsessTaskLifecycleObserver lifecycleObserver) {
         super();
         this.publiserer = publiserer;
-        handleProsessTaskLifecycleObserver = new HandleProsessTaskLifecycleObserver();
+        handleProsessTaskLifecycleObserver = lifecycleObserver;
     }
     
     public void fireEvent(ProsessTaskData data, ProsessTaskStatus gammelStatus, ProsessTaskStatus nyStatus) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImpl.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImpl.java
@@ -255,7 +255,7 @@ public class ProsessTaskRepositoryImpl implements ProsessTaskRepository {
     @Override
     public List<ProsessTaskData> finnUferdigeBatchTasks(String task) {
         TypedQuery<ProsessTaskEntitet> query = entityManager
-            .createQuery("from ProsessTaskEntitet pt where pt.status != 'FERDIG' and pt.taskType = :task", ProsessTaskEntitet.class)
+            .createQuery("from ProsessTaskEntitet pt where pt.status NOT IN ('FERDIG', 'KJOERT') and pt.taskType = :task", ProsessTaskEntitet.class)
             .setParameter("task", task); // NOSONAR $NON-NLS-1$
 
         return tilProsessTask(query.getResultList());
@@ -299,7 +299,7 @@ public class ProsessTaskRepositoryImpl implements ProsessTaskRepository {
         for (ProsessTaskData pt : tasks) {
             // lås alle først
             TypedQuery<ProsessTaskEntitet> query = entityManager
-                .createQuery("from ProsessTaskEntitet pt where pt.status NOT IN (:status, 'FERDIG') and pt.taskType = :task AND pt.id=:id",
+                .createQuery("from ProsessTaskEntitet pt where pt.status NOT IN (:status, 'FERDIG', 'KJOERT') and pt.taskType = :task AND pt.id=:id",
                     ProsessTaskEntitet.class)
                 .setHint(org.hibernate.annotations.QueryHints.FETCH_SIZE, 1)
                 .setParameter("status", status.getDbKode()) // NOSONAR $NON-NLS-1$

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTask.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTask.java
@@ -194,8 +194,8 @@ public class RunTask {
         }
 
         ProsessTaskStatus markerTaskFerdig(ProsessTaskEntitet pte) {
-            ProsessTaskStatus nyStatus = ProsessTaskStatus.FERDIG;
-            taskManagerRepository.oppdaterStatusOgTilFerdig(pte.getId(), nyStatus);
+            ProsessTaskStatus nyStatus = ProsessTaskStatus.KJOERT;
+            taskManagerRepository.oppdaterStatus(pte.getId(), nyStatus);
 
             pte = refreshProsessTask(pte.getId());
             feilOgStatushåndterer.publiserNyStatusEvent(pte.tilProsessTask(), ProsessTaskStatus.KLAR, nyStatus);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/StartupData.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/StartupData.java
@@ -1,0 +1,28 @@
+package no.nav.vedtak.felles.prosesstask.impl;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity(name = "StartupData")
+class StartupData {
+
+    @Id
+    @Column(name = "dbtz")
+    String dbtz;
+    
+    @Column(name = "dbtid")
+    String dbtid;
+    
+    @Column(name = "inputtid")
+    String inputtid;
+    
+    @Column(name="inputtid2")
+    LocalDateTime inputtid2;
+    
+    @Column(name="drift")
+    String drift;
+
+}

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
@@ -164,6 +164,7 @@ public class TaskManager implements AppServiceHandler {
     @Override
     public synchronized void start() {
         if (this.numberOfTaskRunnerThreads > 0) {
+            getTransactionManagerRepository().verifyStartup();
             startTaskThreads();
             startPollerThread();
         } else {
@@ -210,6 +211,9 @@ public class TaskManager implements AppServiceHandler {
      * Poller for tasks og logger jevnlig om det ikke er ledig kapasitet (i in-memory queue) eller ingen tasks funnet (i db).
      */
     protected synchronized List<IdentRunnable> pollForAvailableTasks() {
+        
+        taskManagerRepository.flyttAlleKjoertTilFerdig();
+
         LocalDateTime now = LocalDateTime.now();
 
         int capacity = getRunTaskService().remainingCapacity();
@@ -260,6 +264,7 @@ public class TaskManager implements AppServiceHandler {
         int numberOfTasksStillToGo = numberOfTasksToPoll;
 
         Set<Long> inmemoryTaskIds = getRunTaskService().getTaskIds();
+        
         List<ProsessTaskEntitet> tasksEntiteter = taskManagerRepository
             .pollNesteScrollingUpdate(numberOfTasksStillToGo, waitTimeBeforeNextPollingAttemptSecs, inmemoryTaskIds);
 

--- a/task/src/main/resources/META-INF/pu-default.prosesstask.orm.xml
+++ b/task/src/main/resources/META-INF/pu-default.prosesstask.orm.xml
@@ -9,5 +9,6 @@
     <entity class="no.nav.vedtak.felles.prosesstask.impl.ProsessTaskEntitet"/>
     <entity class="no.nav.vedtak.felles.prosesstask.impl.ProsessTaskType"/>
     <entity class="no.nav.vedtak.felles.prosesstask.impl.ProsessTaskFeilhand"/>
+    <entity class="no.nav.vedtak.felles.prosesstask.impl.StartupData"/>
 
 </entity-mappings>

--- a/task/src/main/resources/no/nav/vedtak/felles/prosesstask/impl/TaskManager_pollTask.sql
+++ b/task/src/main/resources/no/nav/vedtak/felles/prosesstask/impl/TaskManager_pollTask.sql
@@ -31,7 +31,7 @@ WHERE pt.id
                 , feilede_forsoek
             FROM prosess_task pt
             WHERE
-              -- bruker dette itdf. (status != 'FERDIG'). Innført for å bruke partisjoner med minst data, unngår skanning av alle partisjoner
+              -- bruker dette istdf. (status NOT IN('FERDIG', 'KJOERT')). Innført for å bruke partisjoner med minst data, unngår skanning av alle partisjoner
               status in ('FEILET', 'KLAR', 'VENTER_SVAR', 'SUSPENDERT', 'VETO')
           ) tbl
             INNER JOIN prosess_task_type tt ON tt.kode = tbl.task_type

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImplIT.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImplIT.java
@@ -1,5 +1,7 @@
 package no.nav.vedtak.felles.prosesstask.impl;
 
+import static org.junit.Assert.*;
+
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -40,7 +42,7 @@ public class ProsessTaskRepositoryImplIT {
     @Test
     public void test_ingen_match_innenfor_et_kjøretidsintervall() throws Exception {
         List<ProsessTaskStatus> statuser = Arrays.asList(ProsessTaskStatus.values());
-        List<ProsessTaskData> prosessTaskData = prosessTaskRepository.finnAlle(statuser, NÅ.minusHours(1), NÅ);
+        List<ProsessTaskData> prosessTaskData = prosessTaskRepository.finnAlle(statuser, NÅ.minusMinutes(58), NÅ);
 
         Assertions.assertThat(prosessTaskData).isEmpty();
     }
@@ -48,7 +50,7 @@ public class ProsessTaskRepositoryImplIT {
     @Test
     public void test_har_match_innenfor_et_kjøretidsntervall() throws Exception {
         List<ProsessTaskStatus> statuser = Arrays.asList(ProsessTaskStatus.values());
-        List<ProsessTaskData> prosessTaskData = prosessTaskRepository.finnAlle(statuser, NÅ.minusHours(2), NÅ);
+        List<ProsessTaskData> prosessTaskData = prosessTaskRepository.finnAlle(statuser, NÅ.minusHours(2), NÅ.minusHours(1));
 
         Assertions.assertThat(prosessTaskData).hasSize(1);
         Assertions.assertThat(prosessTaskData.get(0).getStatus()).isEqualTo(ProsessTaskStatus.FERDIG);
@@ -89,6 +91,7 @@ public class ProsessTaskRepositoryImplIT {
         flushAndClear();
 
         lagre(lagTestEntitet(ProsessTaskStatus.FERDIG, NÅ.minusHours(2), "hello.world"));
+        lagre(lagTestEntitet(ProsessTaskStatus.KJOERT, NÅ.minusMinutes(59), "hello.world"));
         lagre(lagTestEntitet(ProsessTaskStatus.VENTER_SVAR, NÅ.minusHours(3), "hello.world"));
         lagre(lagTestEntitet(ProsessTaskStatus.FEILET, NÅ.minusHours(4), "hello.world"));
         lagre(lagTestEntitet(ProsessTaskStatus.KLAR, NÅ.minusHours(5), "hello.world"));

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeIT.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeIT.java
@@ -122,7 +122,7 @@ public class TaskManagerRekkefølgeIT {
         assertThat(neste).containsExactly(tasks);
 
         neste.forEach(pt -> {
-            pt.setStatus(ProsessTaskStatus.FERDIG);
+            pt.setStatus(ProsessTaskStatus.KJOERT);
             repo.lagre(pt);
         });
 

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerTest.java
@@ -1,0 +1,25 @@
+package no.nav.vedtak.felles.prosesstask.impl;
+
+import javax.inject.Inject;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import no.nav.vedtak.felles.prosesstask.CdiRunner;
+import no.nav.vedtak.felles.prosesstask.UnittestRepositoryRule;
+
+@RunWith(CdiRunner.class)
+public class TaskManagerTest {
+
+    @Rule
+    public final UnittestRepositoryRule repoRule = new UnittestRepositoryRule();
+
+    @Inject
+    private TaskManagerRepositoryImpl taskManagerRepository;
+    
+    @Test
+    public void sjekk_startup() throws Exception {
+        taskManagerRepository.verifyStartup();
+    }
+}

--- a/task/src/test/resources/META-INF/persistence.xml
+++ b/task/src/test/resources/META-INF/persistence.xml
@@ -8,7 +8,8 @@
         <non-jta-data-source>jdbc/defaultDS</non-jta-data-source>
 		<mapping-file>META-INF/pu-default.prosesstask.orm.xml</mapping-file>
         <properties>
-            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQL10Dialect"/>
+            <property name="hibernate.jdbc.time_zone" value="UTC" />
             <property name="hibernate.connection.autocommit" value="false"/>
             <property name="hibernate.jdbc.use_get_generated_keys" value="true"/>
             <property name="org.hibernate.flushMode" value="COMMIT"/>

--- a/task/src/test/resources/db/migration/defaultDS/1.0.0/V1.0.0_04__constraint-status.sql
+++ b/task/src/test/resources/db/migration/defaultDS/1.0.0/V1.0.0_04__constraint-status.sql
@@ -1,0 +1,1 @@
+alter table prosess_task drop constraint CHK_PROSESS_TASK_STATUS;


### PR DESCRIPTION
Dette setter kjørte task til en pseudo status KJOERT som er i samme partisjon. Dette for å unngå problemer med PostgresSQL der rader flyttes til ny partisjon samtidig som en forsøker å ta en lås på raden (dvs. indre select har funnet en rad, men den er flyttet innen den returneres klient).  Dette er et postgres spesifikt problem som forårsaker feil av type "ERROR: tuple to be locked was already moved to another partition due to concurrent update".  Ved å markere som KJOERT blir det liggende i samme partisjon, så kan det lett ignoreres ved fremtidige spørringer.  En egen operasjon vil da flytte fra KJOERT i default partisjon til FERDIG status og partisjon før neste polling

* Logger db og app tid og tidssone ved startup