### PR TITLE
Rydde opp i bruk av tasktype konfig av ventetid

### DIFF
--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskType.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskType.java
@@ -24,7 +24,7 @@ public class ProsessTaskType {
     private int maksForsøk = 1;
 
     @Column(name = "feil_sek_mellom_forsoek", updatable = false, insertable = false, nullable = false)
-    private int sekundeFørNesteForsøk = 1;
+    private int sekunderFørNesteForsøk = 1;
 
     @ManyToOne
     @JoinColumn(name = "feilhandtering_algoritme", updatable = false, insertable = false)
@@ -62,12 +62,19 @@ public class ProsessTaskType {
         this.cronExpression = cronExpression;
     }
 
+    public ProsessTaskType(String kode, String navn, int maksForsøk, int sekunderFørNesteForsøk) {
+        this.maksForsøk = maksForsøk;
+        this.sekunderFørNesteForsøk = sekunderFørNesteForsøk;
+        this.kode = kode;
+        this.navn = navn;
+    }
+
     public int getMaksForsøk() {
         return maksForsøk;
     }
 
-    public int getSekundeFørNesteForsøk() {
-        return sekundeFørNesteForsøk;
+    public int getSekunderFørNesteForsøk() {
+        return sekunderFørNesteForsøk;
     }
 
     public ProsessTaskFeilhand getFeilhåndteringAlgoritme() {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
@@ -72,7 +72,7 @@ public class RunTaskFeilOgStatusEventHåndterer {
         int failureAttempt = pte.getFeiledeForsøk() + 1;
 
         if (sjekkOmSkalKjøresPåNytt(e, taskType, feilhåndteringsalgoritme, failureAttempt)) {
-            LocalDateTime nyTid = getNesteKjøringForNyKjøring(feilhåndteringsData, feilhåndteringsalgoritme, failureAttempt);
+            LocalDateTime nyTid = getNesteKjøringForNyKjøring(taskType, feilhåndteringsData, feilhåndteringsalgoritme, failureAttempt);
             var feil = kunneIkkeProsessereTaskVilPrøveIgjenEnkelFeilmelding(taskInfo.getId(), taskName, failureAttempt, nyTid, e);
             String feiltekst = getFeiltekstOgLoggEventueltHvisEndret(pte, feil, e, false);
             taskManagerRepository.oppdaterStatusOgNesteKjøring(pte.getId(), ProsessTaskStatus.KLAR, nyTid, feil.kode(), feiltekst, failureAttempt);
@@ -111,10 +111,11 @@ public class RunTaskFeilOgStatusEventHåndterer {
                 taskInfo.getId(), taskInfo.getTaskType(), e);
     }
 
-    private LocalDateTime getNesteKjøringForNyKjøring(ProsessTaskFeilhand feilhåndteringsData,
+    private LocalDateTime getNesteKjøringForNyKjøring(ProsessTaskType taskType,
+            ProsessTaskFeilhand feilhåndteringsData,
             ProsessTaskFeilhåndteringAlgoritme feilhåndteringsalgoritme,
             int failureAttempt) {
-        int secsBetweenAttempts = feilhåndteringsalgoritme.getForsinkelseStrategi().sekunderTilNesteForsøk(failureAttempt,
+        int secsBetweenAttempts = feilhåndteringsalgoritme.getForsinkelseStrategi().sekunderTilNesteForsøk(taskType, failureAttempt,
                 feilhåndteringsData);
 
         LocalDateTime nyTid = LocalDateTime.now().plusSeconds(secsBetweenAttempts);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/BackoffFeilhåndteringStrategi.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/BackoffFeilhåndteringStrategi.java
@@ -1,15 +1,15 @@
 package no.nav.vedtak.felles.prosesstask.impl.feilhåndtering;
 
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskType;
 import no.nav.vedtak.felles.prosesstask.spi.ForsinkelseStrategi;
 import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskFeilHåndteringParametere;
 
 public class BackoffFeilhåndteringStrategi implements ForsinkelseStrategi {
 
-    // TODO (FC): definert noen enkle tall. Bør konfigureres eksternt
-    final int[] backoffIntervaller = new int[]{30, 30, 30, 60}; // NOSONAR
-
     @Override
-    public int sekunderTilNesteForsøk(int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme) {
-        return backoffIntervaller[Math.min(runde, backoffIntervaller.length) - 1];
+    public int sekunderTilNesteForsøk(ProsessTaskType taskType, int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme) {
+        if (runde >= taskType.getMaksForsøk()) throw new IllegalStateException("Manglende limitsjekk");
+        if (runde == 0) return 0;
+        return taskType.getSekunderFørNesteForsøk() * (int) Math.pow(2, (double) runde - 1);
     }
 }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/ÅpningstidForsinkelseStrategi.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/ÅpningstidForsinkelseStrategi.java
@@ -4,6 +4,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskType;
 import no.nav.vedtak.felles.prosesstask.spi.ForsinkelseStrategi;
 import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskFeilHåndteringParametere;
 
@@ -12,12 +13,15 @@ public class ÅpningstidForsinkelseStrategi implements ForsinkelseStrategi {
     private static final int MINIMUM_FORSINKELSE_SEKUNDER = 120;
 
     @Override
-    public int sekunderTilNesteForsøk(int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme) {
-        return sekunderTilNesteForsøk(LocalDateTime.now(), feilhåndteringAlgoritme.getInputVariabel1(), feilhåndteringAlgoritme.getInputVariabel2());
+    public int sekunderTilNesteForsøk(ProsessTaskType taskType, int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme) {
+        if (runde >= taskType.getMaksForsøk()) throw new IllegalStateException("Manglende limitsjekk");
+        var sekunderTilNeste = Math.max(taskType.getSekunderFørNesteForsøk(), MINIMUM_FORSINKELSE_SEKUNDER);
+        return sekunderTilNesteForsøk(LocalDateTime.now(), sekunderTilNeste,
+                feilhåndteringAlgoritme.getInputVariabel1(), feilhåndteringAlgoritme.getInputVariabel2());
     }
 
-    int sekunderTilNesteForsøk(LocalDateTime now, int klokkeslettÅpning, int klokkeslettStenging) {
-        LocalDateTime forsinket = now.plusSeconds(MINIMUM_FORSINKELSE_SEKUNDER);
+    int sekunderTilNesteForsøk(LocalDateTime now, int sekunderTilNeste, int klokkeslettÅpning, int klokkeslettStenging) {
+        LocalDateTime forsinket = now.plusSeconds(sekunderTilNeste);
         if (forsinket.getHour() < klokkeslettÅpning) {
             forsinket = forsinket.withHour(klokkeslettÅpning);
         } else if (forsinket.getHour() >= klokkeslettStenging) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/spi/ForsinkelseStrategi.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/spi/ForsinkelseStrategi.java
@@ -1,5 +1,7 @@
 package no.nav.vedtak.felles.prosesstask.spi;
 
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskType;
+
 public interface ForsinkelseStrategi {
-    int sekunderTilNesteForsøk(int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme);
+    int sekunderTilNesteForsøk(ProsessTaskType taskType, int runde, ProsessTaskFeilHåndteringParametere feilhåndteringAlgoritme);
 }

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/DefaultForsinkelseStrategiTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/DefaultForsinkelseStrategiTest.java
@@ -1,0 +1,45 @@
+package no.nav.vedtak.felles.prosesstask.impl.feilhåndtering;
+
+import static no.nav.vedtak.felles.prosesstask.impl.feilhåndtering.ÅpningstidForsinkelseStrategiTest.klokkeslettÅpning;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskType;
+
+public class DefaultForsinkelseStrategiTest {
+
+    private static final ProsessTaskType TASK_TYPE = new ProsessTaskType("test", "Test", 4, 15);
+
+    BackoffFeilhåndteringStrategi strategi = new BackoffFeilhåndteringStrategi();
+
+    @Test
+    public void forsøk_0_gir_0s() {
+        int i = strategi.sekunderTilNesteForsøk(TASK_TYPE, 0, null);
+        assertThat(i).isZero();
+    }
+
+    @Test
+    public void forsøk_1_gir_15s() {
+        int i = strategi.sekunderTilNesteForsøk(TASK_TYPE, 1, null);
+        assertThat(i).isEqualTo(15);
+    }
+
+    @Test
+    public void forsøk_2_gir_30s() {
+        int i = strategi.sekunderTilNesteForsøk(TASK_TYPE, 2, null);
+        assertThat(i).isEqualTo(30);
+    }
+
+    @Test
+    public void forsøk_3_gir_60s() {
+        int i = strategi.sekunderTilNesteForsøk(TASK_TYPE, 3, null);
+        assertThat(i).isEqualTo(60);
+    }
+
+
+}

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/ÅpningstidForsinkelseStrategiTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/feilhåndtering/ÅpningstidForsinkelseStrategiTest.java
@@ -18,7 +18,7 @@ public class ÅpningstidForsinkelseStrategiTest {
     public void utenforÅpningsTidTest() {
         LocalDateTime localDateTime = LocalDateTime.of(2017, 6, 14, 5, 5, 5);
         LocalDateTime expected = LocalDateTime.of(2017, 6, 14, klokkeslettÅpning, 5, 5);
-        int i = strategi.sekunderTilNesteForsøk(localDateTime, klokkeslettÅpning, klokkeslettStenging);
+        int i = strategi.sekunderTilNesteForsøk(localDateTime, 120, klokkeslettÅpning, klokkeslettStenging);
         long diff = expected.toEpochSecond(ZoneOffset.UTC) - localDateTime.toEpochSecond(ZoneOffset.UTC) + 120;
         Assertions.assertEquals(i, diff);
     }
@@ -26,7 +26,7 @@ public class ÅpningstidForsinkelseStrategiTest {
     @Test
     public void innenforÅpningsTidTest() {
         LocalDateTime localDateTime = LocalDateTime.of(2017, 6, 14, 10, 5, 5);
-        int i = strategi.sekunderTilNesteForsøk(localDateTime, klokkeslettÅpning, klokkeslettStenging);
+        int i = strategi.sekunderTilNesteForsøk(localDateTime, 120, klokkeslettÅpning, klokkeslettStenging);
         Assertions.assertTrue(i == 120);
     }
 
@@ -34,7 +34,7 @@ public class ÅpningstidForsinkelseStrategiTest {
     public void helgenÅpningsTidTest() {
         LocalDateTime localDateTime = LocalDateTime.of(2017, 6, 17, 10, 5, 5);
         LocalDateTime expected = LocalDateTime.of(2017, 6, 19, klokkeslettÅpning, 5, 5);
-        int i = strategi.sekunderTilNesteForsøk(localDateTime, klokkeslettÅpning, klokkeslettStenging);
+        int i = strategi.sekunderTilNesteForsøk(localDateTime, 120, klokkeslettÅpning, klokkeslettStenging);
         long diff = expected.toEpochSecond(ZoneOffset.UTC) - localDateTime.toEpochSecond(ZoneOffset.UTC) + 120;
         Assertions.assertEquals(i, diff);
     }


### PR DESCRIPTION
Neste steg er å vurdere å trekke ut tasktype-konfig og feilhåndtering-konfig til kode. Enumifiseringsjobb.
Ikke lenger samme dynamikk i nye tasks - så mindre behov for å styre - mer behov for påminnelse av hva som skal til