### PR TITLE
Monitor for utvalgte statuser

### DIFF
--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
@@ -6,10 +6,15 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
 
 public class TaskMonitor {
 
     public static final String TASK = "prosesstask.";
+
+    public static final Timer TASK_TIMER = Timer.builder(TASK + "timer")
+        .publishPercentileHistogram()
+        .register(Metrics.globalRegistry);
 
     private static final Map<ProsessTaskStatus, AtomicInteger> TASK_GAUGES = Map.of(
         ProsessTaskStatus.KLAR, statusGauge(ProsessTaskStatus.KLAR),

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
@@ -1,0 +1,41 @@
+package no.nav.vedtak.felles.prosesstask.api;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.micrometer.core.instrument.Metrics;
+
+public class TaskMonitor {
+
+    public static final String TASK = "prosesstask.";
+
+    private static final Map<ProsessTaskStatus, AtomicInteger> TASK_GAUGES = Map.of(
+        ProsessTaskStatus.KLAR, statusGauge(ProsessTaskStatus.KLAR),
+        ProsessTaskStatus.VENTER_SVAR, statusGauge("venter"),
+        ProsessTaskStatus.VETO, statusGauge(ProsessTaskStatus.VETO),
+        ProsessTaskStatus.FEILET, statusGauge(ProsessTaskStatus.FEILET)
+    );
+
+    private TaskMonitor() {
+        // NOSONAR
+    }
+
+    public static void setStatusCount(ProsessTaskStatus status, Integer antall) {
+        Optional.ofNullable(TASK_GAUGES.get(status)).ifPresent(a -> a.set(antall));
+    }
+
+    public static Set<ProsessTaskStatus> monitoredStatuses() {
+        return TASK_GAUGES.keySet();
+    }
+
+    private static AtomicInteger statusGauge(ProsessTaskStatus status) {
+        return statusGauge(status.name().toLowerCase());
+    }
+
+    private static AtomicInteger statusGauge(String name) {
+        return Metrics.gauge(TASK + name, new AtomicInteger(0));
+    }
+
+}

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
@@ -14,6 +14,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.TaskMonitor;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.prosesstask.impl.cron.CronExpression;
 import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskRetryPolicy;
@@ -94,7 +95,7 @@ public class ProsessTaskHandlerRef implements AutoCloseable {
 
     public void doTask(ProsessTaskData data) {
         LOG.info("Starter task {}", data.getTaskType());
-        bean.doTask(data);
+        TaskMonitor.TASK_TIMER.record(() -> bean.doTask(data));
         LOG.info("Stoppet task {}", data.getTaskType());
     }
 

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
@@ -11,14 +11,12 @@ import org.jboss.weld.interceptor.util.proxy.TargetInstanceProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.micrometer.core.instrument.Metrics;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.prosesstask.impl.cron.CronExpression;
 import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskRetryPolicy;
-import no.nav.vedtak.log.metrics.MetricsUtil;
 
 /**
  *  Referanse til en {@link ProsessTaskHandler}.
@@ -26,11 +24,6 @@ import no.nav.vedtak.log.metrics.MetricsUtil;
 
 public class ProsessTaskHandlerRef implements AutoCloseable {
 
-    private static final String METRIC_NAME = "task";
-
-    static {
-        MetricsUtil.utvidMedMedian(METRIC_NAME);
-    }
     private static final Logger LOG = LoggerFactory.getLogger(ProsessTaskHandlerRef.class);
 
     private final ProsessTaskHandler bean;
@@ -101,7 +94,7 @@ public class ProsessTaskHandlerRef implements AutoCloseable {
 
     public void doTask(ProsessTaskData data) {
         LOG.info("Starter task {}", data.getTaskType());
-        Metrics.timer(METRIC_NAME, "type", data.getTaskType()).record(() -> bean.doTask(data));
+        bean.doTask(data);
         LOG.info("Stoppet task {}", data.getTaskType());
     }
 

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/RunTaskFeilOgStatusEventHåndterer.java
@@ -1,6 +1,5 @@
 package no.nav.vedtak.felles.prosesstask.impl;
 
-import static io.micrometer.core.instrument.Metrics.counter;
 import static no.nav.vedtak.felles.prosesstask.impl.TaskManagerFeil.kunneIkkeProsessereTaskVilIkkePrøveIgjenEnkelFeilmelding;
 import static no.nav.vedtak.felles.prosesstask.impl.TaskManagerFeil.kunneIkkeProsessereTaskVilPrøveIgjenEnkelFeilmelding;
 
@@ -21,12 +20,6 @@ import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskRetryPolicy;
  * tasks.
  */
 public class RunTaskFeilOgStatusEventHåndterer {
-
-    private static final String TYPE = "type";
-
-    private static final String TASK_FEIL = "task.feil";
-
-    private static final String SEVERITY = "severity";
 
     private static final Logger LOG = LoggerFactory.getLogger(RunTaskFeilOgStatusEventHåndterer.class);
 
@@ -77,7 +70,6 @@ public class RunTaskFeilOgStatusEventHåndterer {
         var nyStatus = ProsessTaskStatus.FEILET;
         try {
             publiserNyStatusEvent(pte.tilProsessTask(), pte.getStatus(), nyStatus, feil, e);
-            count("fatal");
         } finally {
             int failureAttempt = pte.getFeiledeForsøk() + 1;
             String feiltekst = getFeiltekstOgLoggEventueltHvisEndret(pte, feil, e, true);
@@ -141,8 +133,4 @@ public class RunTaskFeilOgStatusEventHåndterer {
         return feiltekst;
     }
 
-    // TODO (monitorering): erstatt med gauges som teller absolutt antall klar, feilet, ventersvar, (veto / suspendert)?
-    private void count(String severity) {
-        counter(TASK_FEIL, SEVERITY, severity, TYPE, taskInfo.getTaskType().value()).increment();
-    }
 }

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeIT.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeIT.java
@@ -14,6 +14,7 @@ import no.nav.vedtak.felles.prosesstask.JpaExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
+import no.nav.vedtak.felles.prosesstask.api.TaskMonitor;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 
 public class TaskManagerRekkefølgeIT {
@@ -45,6 +46,10 @@ public class TaskManagerRekkefølgeIT {
 
         // Act
         repo.lagre(sammensatt);
+        var monitor = taskManagerRepo.countTasksForStatus(TaskMonitor.monitoredStatuses());
+        assertThat(monitor).containsEntry(ProsessTaskStatus.KLAR, 3);
+        assertThat(monitor.get(ProsessTaskStatus.VENTER_SVAR)).isNull();
+        assertThat(monitor.get(ProsessTaskStatus.FEILET)).isNull();
 
         pollEnRundeVerifiserOgFerdigstill(pt1);
 


### PR DESCRIPTION
Enkel monitor for telling av tasks pr status. 
Vil bli scraped av prometheus og tilgjengelig i promQL (bruk max for gauge) -> Grafana + Alerterator
Telletråd kjører etter 15s deretter med 3.9 minutts mellomrom.
Query kjører på 10-100 ms på ORCL og PG i prod.

Noe for K9?