### PR TITLE
Ny taskdispatcher for felles/kontekst

### DIFF
--- a/kontekst/pom.xml
+++ b/kontekst/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>prosesstask-root</artifactId>
+        <groupId>no.nav.vedtak.prosesstask</groupId>
+        <version>0.0.0-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>prosesstask-kontekst</artifactId>
+
+    <name>Prosesstask :: Bridge mot felles/trådkontekst</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+
+        <dependency>
+            <!-- Trengs for implementasjon av TaskManager -->
+            <groupId>no.nav.vedtak.prosesstask</groupId>
+            <artifactId>prosesstask</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-log</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-db</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger.felles</groupId>
+            <artifactId>felles-kontekst</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
@@ -33,23 +33,24 @@ public class KontekstCdiProsessTaskDispatcher extends BasicCdiProsessTaskDispatc
     }
 
     @Override
-    public void dispatch(ProsessTaskHandlerRef taskHandler, ProsessTaskData task) {
+    public void dispatch(ProsessTaskData task) {
+        try (ProsessTaskHandlerRef taskHandler = taskHandler(task.taskType())) {
+            if (task.getSaksnummer() != null) {
+                LOG_CONTEXT.add("fagsak", task.getSaksnummer()); // NOSONAR //$NON-NLS-1$
+            } else if (task.getFagsakId() != null) {
+                LOG_CONTEXT.add("fagsak", task.getFagsakId()); // NOSONAR //$NON-NLS-1$
+            }
+            if (task.getBehandlingId() != null) {
+                LOG_CONTEXT.add("behandling", task.getBehandlingId()); // NOSONAR //$NON-NLS-1$
+            } else if (task.getBehandlingUuid() != null) {
+                LOG_CONTEXT.add("behandling", task.getBehandlingUuid()); // NOSONAR //$NON-NLS-1$
+            }
 
-        if (task.getSaksnummer() != null) {
-            LOG_CONTEXT.add("fagsak", task.getSaksnummer()); // NOSONAR //$NON-NLS-1$
-        } else if (task.getFagsakId() != null) {
-            LOG_CONTEXT.add("fagsak", task.getFagsakId()); // NOSONAR //$NON-NLS-1$
+            taskHandler.doTask(task);
+
+            taskAuditlogger.logg(task);
+            // renser ikke LOG_CONTEXT her. tar alt i RunTask slik at vi kan logge exceptions også
         }
-        if (task.getBehandlingId() != null) {
-            LOG_CONTEXT.add("behandling", task.getBehandlingId()); // NOSONAR //$NON-NLS-1$
-        } else if (task.getBehandlingUuid() != null) {
-            LOG_CONTEXT.add("behandling", task.getBehandlingUuid()); // NOSONAR //$NON-NLS-1$
-        }
-
-        taskHandler.doTask(task);
-
-        taskAuditlogger.logg(task);
-        // renser ikke LOG_CONTEXT her. tar alt i RunTask slik at vi kan logge exceptions også
     }
 
     @SuppressWarnings("resource")

--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
@@ -1,0 +1,88 @@
+package no.nav.vedtak.prosesstask.kontekst;
+
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.TaskType;
+import no.nav.vedtak.felles.prosesstask.impl.BasicCdiProsessTaskDispatcher;
+import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskHandlerRef;
+import no.nav.vedtak.felles.prosesstask.log.TaskAuditlogger;
+import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+import no.nav.vedtak.sikkerhet.kontekst.SystemKontekst;
+
+/**
+ * Implementerer dispatch vha. CDI scoped beans.
+ */
+@ApplicationScoped
+public class KontekstCdiProsessTaskDispatcher extends BasicCdiProsessTaskDispatcher {
+    private static final MdcExtendedLogContext LOG_CONTEXT = MdcExtendedLogContext.getContext("prosess"); //$NON-NLS-1$
+
+    private final TaskAuditlogger taskAuditlogger;
+
+    @Inject
+    public KontekstCdiProsessTaskDispatcher(TaskAuditlogger taskAuditlogger) {
+        super(Set.of(TekniskException.class, IntegrasjonException.class));
+        this.taskAuditlogger = taskAuditlogger;
+    }
+
+    @Override
+    public void dispatch(ProsessTaskHandlerRef taskHandler, ProsessTaskData task) {
+
+        if (task.getSaksnummer() != null) {
+            LOG_CONTEXT.add("fagsak", task.getSaksnummer()); // NOSONAR //$NON-NLS-1$
+        } else if (task.getFagsakId() != null) {
+            LOG_CONTEXT.add("fagsak", task.getFagsakId()); // NOSONAR //$NON-NLS-1$
+        }
+        if (task.getBehandlingId() != null) {
+            LOG_CONTEXT.add("behandling", task.getBehandlingId()); // NOSONAR //$NON-NLS-1$
+        } else if (task.getBehandlingUuid() != null) {
+            LOG_CONTEXT.add("behandling", task.getBehandlingUuid()); // NOSONAR //$NON-NLS-1$
+        }
+
+        taskHandler.doTask(task);
+
+        taskAuditlogger.logg(task);
+        // renser ikke LOG_CONTEXT her. tar alt i RunTask slik at vi kan logge exceptions også
+    }
+
+    @SuppressWarnings("resource")
+    @Override
+    public ProsessTaskHandlerRef taskHandler(TaskType taskType) {
+        return KontekstProsessTaskHandlerRef.lookup(taskType);
+    }
+
+    private static class KontekstProsessTaskHandlerRef extends ProsessTaskHandlerRef {
+
+        private KontekstProsessTaskHandlerRef(ProsessTaskHandler bean) {
+            super(bean);
+        }
+
+        @Override
+        public void close() {
+            super.close();
+            if (KontekstHolder.harKontekst()) {
+                KontekstHolder.fjernKontekst();
+            }
+        }
+
+        @Override
+        public void doTask(ProsessTaskData prosessTaskData) {
+            KontekstHolder.setKontekst(SystemKontekst.forProsesstask());
+            super.doTask(prosessTaskData);
+        }
+
+        public static KontekstProsessTaskHandlerRef lookup(TaskType taskType) {
+            var bean = ProsessTaskHandlerRef.lookupHandler(taskType);
+            return new KontekstProsessTaskHandlerRef(bean);
+        }
+
+    }
+
+}

--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
@@ -14,8 +14,8 @@ import no.nav.vedtak.felles.prosesstask.impl.BasicCdiProsessTaskDispatcher;
 import no.nav.vedtak.felles.prosesstask.impl.ProsessTaskHandlerRef;
 import no.nav.vedtak.felles.prosesstask.log.TaskAuditlogger;
 import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
+import no.nav.vedtak.sikkerhet.kontekst.BasisKontekst;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
-import no.nav.vedtak.sikkerhet.kontekst.SystemKontekst;
 
 /**
  * Implementerer dispatch vha. CDI scoped beans.
@@ -75,7 +75,7 @@ public class KontekstCdiProsessTaskDispatcher extends BasicCdiProsessTaskDispatc
 
         @Override
         public void doTask(ProsessTaskData prosessTaskData) {
-            KontekstHolder.setKontekst(SystemKontekst.forProsesstask());
+            KontekstHolder.setKontekst(BasisKontekst.forProsesstask());
             super.doTask(prosessTaskData);
         }
 

--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstSubjectProvider.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstSubjectProvider.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import javax.enterprise.context.Dependent;
 
 import no.nav.vedtak.felles.prosesstask.impl.SubjectProvider;
-import no.nav.vedtak.sikkerhet.kontekst.AbstraktKontekst;
+import no.nav.vedtak.sikkerhet.kontekst.Kontekst;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 import no.nav.vedtak.sikkerhet.kontekst.Systembruker;
 
@@ -16,7 +16,7 @@ public class KontekstSubjectProvider implements SubjectProvider {
     @Override
     public String getUserIdentity() {
         // TODO endre når vi slutter med klassisk systembruker og går over til Azure - enten appnavn eller srv<appnavn>
-        return Optional.ofNullable(KontekstHolder.getKontekst()).map(AbstraktKontekst::getUid)
+        return Optional.ofNullable(KontekstHolder.getKontekst()).map(Kontekst::getKompaktUid)
             .orElseGet(Systembruker::username);
     }
 

--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstSubjectProvider.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstSubjectProvider.java
@@ -1,0 +1,24 @@
+package no.nav.vedtak.prosesstask.kontekst;
+
+import java.util.Optional;
+
+import javax.enterprise.context.Dependent;
+
+import no.nav.vedtak.felles.prosesstask.impl.SubjectProvider;
+import no.nav.vedtak.sikkerhet.kontekst.AbstraktKontekst;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+import no.nav.vedtak.sikkerhet.kontekst.Systembruker;
+
+/** henter brukernavn fra kontekst i felles. */
+@Dependent
+public class KontekstSubjectProvider implements SubjectProvider {
+
+    @Override
+    public String getUserIdentity() {
+        // TODO endre når vi slutter med klassisk systembruker og går over til Azure - enten appnavn eller srv<appnavn>
+        return Optional.ofNullable(KontekstHolder.getKontekst()).map(AbstraktKontekst::getUid)
+            .orElseGet(Systembruker::username);
+    }
+
+}
+

--- a/kontekst/src/main/resources/META-INF/beans.xml
+++ b/kontekst/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_2_0.xsd" 
+	version="2.0" 
+	bean-discovery-mode="annotated">
+</beans>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
 		<module>task</module>
 		<module>legacy</module>
 		<module>rest</module>
-	</modules>
+        <module>kontekst</module>
+    </modules>
 
 	<properties>
 		<java.version>17</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>no.nav.foreldrepenger.felles</groupId>
 		<artifactId>fp-bom</artifactId>
-		<version>0.4.1</version>
+		<version>0.4.3</version>
 	</parent>
 
 	<groupId>no.nav.vedtak.prosesstask</groupId>
@@ -53,7 +53,7 @@
 		<sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
 		<sonar.projectKey>navikt_fp-prosesstask</sonar.projectKey>
 
-		<felles.version>4.2.22</felles.version>
+		<felles.version>4.2.25</felles.version>
 	</properties>
 
 	<repositories>
@@ -69,7 +69,7 @@
 			<dependency>
 				<groupId>no.nav.foreldrepenger.felles</groupId>
 				<artifactId>fp-bom</artifactId>
-				<version>0.4.1</version>
+				<version>0.4.3</version>
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>


### PR DESCRIPTION
Må vente litt med denne - som setter kontekst og omgår sikkerhet/ContainerLogin 
Skal sjekke logging av ny mekanisme i felles og så legge om felles sin token-provider til å se på Kontekst.
Må fintenke litt når det er i gang - men målet er at prosesstask setter kontekst = task og at tokenprovider så henter AzureCC eller STS avhengig av target og at fp-apps bruker AzureCC internt.