### PR TITLE
Fjerner tasktimer - bedre å query slutt-start for å tune

### DIFF
--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskMonitor.java
@@ -7,14 +7,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.core.instrument.Metrics;
 import io.micrometer.core.instrument.Tags;
-import io.micrometer.core.instrument.Timer;
 
 public class TaskMonitor {
 
-    public static final String TASK_LENGDE = "prosesstask.lengde";
     public static final String TASK_ANTALL = "prosesstask.antall";
-
-    public static final Timer TASK_TIMER = Metrics.timer(TASK_LENGDE);
 
     public static final Map<ProsessTaskStatus, AtomicInteger> TASK_GAUGES = Map.of(
         ProsessTaskStatus.KLAR, statusGauge(ProsessTaskStatus.KLAR),
@@ -24,7 +20,7 @@ public class TaskMonitor {
     );
 
     private TaskMonitor() {
-        
+
     }
 
     public static void setStatusCount(ProsessTaskStatus status, Integer antall) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
-import no.nav.vedtak.felles.prosesstask.api.TaskMonitor;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.prosesstask.impl.cron.CronExpression;
 import no.nav.vedtak.felles.prosesstask.spi.ProsessTaskRetryPolicy;
@@ -87,15 +86,14 @@ public class ProsessTaskHandlerRef implements AutoCloseable {
         }
 
         if (bean.getClass().isAnnotationPresent(Dependent.class)) {
-            // må closes hvis @Dependent scoped siden vi slår opp. ApplicationScoped alltid
-            // ok. RequestScope også ok siden vi kjører med det.
+            // må closes hvis @Dependent scoped siden vi slår opp. ApplicationScoped alltid ok. RequestScope også ok siden vi kjører med det.
             CDI.current().destroy(bean);
         }
     }
 
     public void doTask(ProsessTaskData data) {
         LOG.info("Starter task {}", data.getTaskType());
-        TaskMonitor.TASK_TIMER.record(() -> bean.doTask(data));
+        bean.doTask(data);
         LOG.info("Stoppet task {}", data.getTaskType());
     }
 


### PR DESCRIPTION
Beholder opptelling av antall klar/feilet/... med mellomrom 3-9 minutt (må bruke max over alle pods i PrometheusQL).
Fjerner task-timer. Ganske mange task-typer fra fpsak.
Det er generelt sett enklere å analysere oppførsel ved å kjøre query slutt-start mot prosess_task-tabell over periode for å se de som er godt over medianen. Enkelte (fortsettBehandling) vil ha svært varierende kjøretid (<1s for ett steg til 30s for fullauto).