### PR TITLE
Fjerne behov for hibernate.dialect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<sonar.projectName>fp-prosesstask</sonar.projectName>
 		<sonar.projectKey>navikt_fp-prosesstask</sonar.projectKey>
 
-		<felles.version>7.0.0</felles.version>
+		<felles.version>7.0.1</felles.version>
 
         <jakarta.jakartaee-bom.version>10.0.0</jakarta.jakartaee-bom.version>
         <hibernate-core.version>6.3.2.Final</hibernate-core.version>
@@ -235,7 +235,7 @@
             <dependency>
                 <groupId>org.flywaydb</groupId>
                 <artifactId>flyway-database-postgresql</artifactId>
-                <version>10.1.0</version>
+                <version>10.2.0</version>
             </dependency>
 
             <dependency>

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/util/DatabaseUtil.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/util/DatabaseUtil.java
@@ -1,32 +1,62 @@
 package no.nav.vedtak.felles.prosesstask.impl.util;
 
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+
 import jakarta.persistence.EntityManager;
 
 public class DatabaseUtil {
+
+    private static final Map<String, String> CACHE_DIALECT = new ConcurrentHashMap<>();
 
     private DatabaseUtil() {
     }
 
     public static boolean isPostgres(EntityManager entityManager) {
-        return getDialect(entityManager).contains("PostgreSQL");
+        return getDatabaseDialect(entityManager).filter(DatabaseUtil::isPostgres).isPresent();
     }
 
     public static boolean isOracle(EntityManager entityManager) {
-        return getDialect(entityManager).contains("Oracle");
+        return getDatabaseDialect(entityManager).filter(DatabaseUtil::isOracle).isPresent();
     }
 
     public static String getDialect(EntityManager entityManager) {
-        return (String) entityManager.getEntityManagerFactory().getProperties().get("hibernate.dialect");
+        return getDatabaseDialect(entityManager).orElse("unknown");
     }
 
     public static String getSqlForUniktGruppeNavn(EntityManager entityManager) {
-        if (DatabaseUtil.isPostgres(entityManager)) {
+        var dialect = getDatabaseDialect(entityManager);
+        if (dialect.filter(DatabaseUtil::isPostgres).isPresent()) {
             return "SELECT nextval('seq_prosess_task_gruppe')";
         }
-        if (DatabaseUtil.isOracle(entityManager)) {
+        if (dialect.filter(DatabaseUtil::isOracle).isPresent()) {
             return "SELECT seq_prosess_task_gruppe.nextval FROM dual";
         }
-        throw new UnsupportedOperationException("Unsupported Database: " + DatabaseUtil.getDialect(entityManager));
+        throw new UnsupportedOperationException("Unsupported Database: " + getDatabaseDialect(entityManager).orElse("unknown"));
+    }
 
+    private static Optional<String> getDatabaseDialect(EntityManager entityManager) {
+        if (entityManager.getEntityManagerFactory() instanceof SessionFactoryImplementor sfi) {
+            var key = sfi.getUuid();
+            if (!CACHE_DIALECT.containsKey(key)) {
+                var dialectClass = sfi.getJdbcServices().getDialect();
+                if (dialectClass != null) {
+                    CACHE_DIALECT.put(key, dialectClass.getClass().getSimpleName().toLowerCase());
+                }
+            }
+            return Optional.ofNullable(CACHE_DIALECT.get(key));
+        }
+        return Optional.empty();
+    }
+
+    private static boolean isOracle(String s) {
+        return s.startsWith("oracle");
+    }
+
+    private static boolean isPostgres(String s) {
+        return s.startsWith("postgres");
     }
 }

--- a/task/src/test/resources/META-INF/persistence.xml
+++ b/task/src/test/resources/META-INF/persistence.xml
@@ -9,7 +9,6 @@
 		<non-jta-data-source>jdbc/defaultDS</non-jta-data-source>
 
 		<properties>
-			<property name="hibernate.dialect" value="org.hibernate.dialect.PostgreSQLDialect" />
 			<property name="hibernate.jdbc.time_zone" value="UTC"/>
 
 			<property name="hibernate.jdbc.use_get_generated_keys" value="true" />


### PR DESCRIPTION
Det blir litt tungt med flyway-metoden, egne pakker for hver db, pga prosesstask-kontekst og prosesstask-rest