### PR TITLE
Prosesstask kan annoteres med default prioritet

### DIFF
--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTask.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTask.java
@@ -51,6 +51,12 @@ public @interface ProsessTask {
     String value();
 
     /**
+     * Standard prioritet for task type
+     */
+    @Nonbinding
+    int prioritet() default 1;
+
+    /**
      * Cron-expression to schedule next instance of a repeating task.
      */
     @Nonbinding

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
@@ -49,7 +49,9 @@ public class ProsessTaskData implements ProsessTaskInfo {
     }
 
     public static ProsessTaskData forProsessTask(Class<? extends ProsessTaskHandler> clazz) {
-        return new ProsessTaskData(TaskType.forProsessTask(clazz));
+        var prosessTaskData = new ProsessTaskData(TaskType.forProsessTask(clazz));
+        prosessTaskData.setPrioritet(TaskType.prioritet(clazz));
+        return prosessTaskData;
     }
 
     public static ProsessTaskData forTaskType(TaskType taskType) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskDataBuilder.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskDataBuilder.java
@@ -20,7 +20,7 @@ public class ProsessTaskDataBuilder {
     }
 
     public static ProsessTaskDataBuilder forProsessTask(Class<? extends ProsessTaskHandler> clazz) {
-        return new ProsessTaskDataBuilder(TaskType.forProsessTask(clazz));
+        return new ProsessTaskDataBuilder(TaskType.forProsessTask(clazz)).medPrioritet(TaskType.prioritet(clazz));
     }
 
     public static ProsessTaskDataBuilder forTaskType(TaskType taskType) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskType.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/TaskType.java
@@ -17,4 +17,8 @@ public record TaskType(String value) {
     public static TaskType forProsessTask(Class<? extends ProsessTaskHandler> clazz) {
         return new TaskType(clazz.getAnnotation(ProsessTask.class).value());
     }
+
+    public static int prioritet(Class<? extends ProsessTaskHandler> clazz) {
+        return clazz.getAnnotation(ProsessTask.class).prioritet();
+    }
 }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHandlerRef.java
@@ -3,14 +3,13 @@ package no.nav.vedtak.felles.prosesstask.impl;
 import java.lang.annotation.Annotation;
 import java.util.Set;
 
-import jakarta.enterprise.context.Dependent;
-import jakarta.enterprise.inject.spi.CDI;
-import jakarta.enterprise.util.AnnotationLiteral;
-
 import org.jboss.weld.interceptor.util.proxy.TargetInstanceProxy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.util.AnnotationLiteral;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
@@ -109,6 +108,11 @@ public class ProsessTaskHandlerRef implements AutoCloseable {
         @Override
         public String value() {
             return taskType;
+        }
+
+        @Override
+        public int prioritet() {
+            return 1;
         }
 
         @Override

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskTjenesteImplTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskTjenesteImplTest.java
@@ -37,7 +37,7 @@ class ProsessTaskTjenesteImplTest {
 
     private ProsessTaskTjeneste prosessTaskTjeneste;
 
-    @ProsessTask(TASK_TYPE_NAME_OPPR)
+    @ProsessTask(value = TASK_TYPE_NAME_OPPR, prioritet = 3)
     private static class DummyHandlerOpprett implements ProsessTaskHandler {
         @Override
         public void doTask(ProsessTaskData prosessTaskData) {
@@ -61,6 +61,8 @@ class ProsessTaskTjenesteImplTest {
                 .medProperty(REQUIRED_PROPERTY, "Verdi")
                 .build();
 
+        assertThat(ptd.getPriority()).isEqualTo(TaskType.prioritet(DummyHandlerOpprett.class));
+
         when(prosessTaskRepositoryMock.lagre(any(ProsessTaskData.class))).thenReturn("gruppe-id");
 
         prosessTaskTjeneste.lagreValidert(ptd);
@@ -72,6 +74,7 @@ class ProsessTaskTjenesteImplTest {
 
         verify(prosessTaskRepositoryMock, times(1)).lagre(any(ProsessTaskGruppe.class));
         assertThat(dataTilPersistering.getTasks().get(0).task().taskType()).isEqualTo(TaskType.forProsessTask(DummyHandlerOpprett.class));
+        assertThat(dataTilPersistering.getTasks().get(0).task().getPriority()).isEqualTo(TaskType.prioritet(DummyHandlerOpprett.class));
     }
 
     @Test


### PR DESCRIPTION
Ønsker gå til prioritet i smalt intervall 1,2,3,4 - der 1 er normal/høy, 3 er batch, mens 4 er migrering. Gir bedre ytelse
Kan nå annotere en prosesstask med standard prioritet som blir satt når man lager en ProsessTaskData