### PR TITLE
Forenklet api for sak/behandling

### DIFF
--- a/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
+++ b/kontekst/src/main/java/no/nav/vedtak/prosesstask/kontekst/KontekstCdiProsessTaskDispatcher.java
@@ -35,10 +35,10 @@ public class KontekstCdiProsessTaskDispatcher extends BasicCdiProsessTaskDispatc
             } else if (task.getFagsakId() != null) { // NOSONAR
                 LOG_CONTEXT.add("fagsak", task.getFagsakId());  // NOSONAR
             }
-            if (task.getBehandlingId() != null) {
-                LOG_CONTEXT.add("behandling", task.getBehandlingId());
-            } else if (task.getBehandlingUuid() != null) {
+            if (task.getBehandlingUuid() != null) {
                 LOG_CONTEXT.add("behandling", task.getBehandlingUuid());
+            } else if (task.getBehandlingId() != null) {
+                LOG_CONTEXT.add("behandling", task.getBehandlingId());
             }
 
             taskHandler.doTask(task);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/CommonTaskProperties.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/CommonTaskProperties.java
@@ -12,16 +12,5 @@ public class CommonTaskProperties {
     public static final String BEHANDLING_ID ="behandlingId";
     public static final String BEHANDLING_UUID = "behandlingUuid";
     public static final String SAKSNUMMER = "saksnummer";
-    /**
-     * Erstatt med saksnummer
-     * @deprecated use saksnummer
-     */
-    @Deprecated(forRemoval = true)
-    public static final String FAGSAK_ID = "fagsakId";
-
-    /*
-     * Reservert for tasks med status VENTER_SVAR
-     */
-    static final String HENDELSE_PROPERTY = "hendelse";
 
 }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
@@ -22,6 +22,18 @@ public class ProsessTaskData implements ProsessTaskInfo {
     public static final String MANGLER_PROPS = "PT-492717";
     public static final Pattern VALID_KEY_PATTERN = Pattern.compile("[a-zA-Z0-9_\\.]+$");
 
+    /**
+     * Erstatt med saksnummer
+     * @deprecated use saksnummer
+     */
+    // @Deprecated(forRemoval = true) - venter til FagsakProsesstask fikset
+    private static final String FAGSAK_ID = "fagsakId";
+
+    /*
+     * Reservert for tasks med status VENTER_SVAR
+     */
+    private static final String HENDELSE_PROPERTY = "hendelse";
+
     private final Properties props = new Properties();
     private final TaskType taskType;
     private int antallFeiledeForsøk;
@@ -109,11 +121,11 @@ public class ProsessTaskData implements ProsessTaskInfo {
 
     @Override
     public Optional<String> getVentetHendelse() {
-        return Optional.ofNullable(getPropertyValue(CommonTaskProperties.HENDELSE_PROPERTY));
+        return Optional.ofNullable(getPropertyValue(HENDELSE_PROPERTY));
     }
 
     void setVentetHendelse(String hendelse) {
-        setProperty(CommonTaskProperties.HENDELSE_PROPERTY, hendelse);
+        setProperty(HENDELSE_PROPERTY, hendelse);
     }
 
     @Override
@@ -281,11 +293,10 @@ public class ProsessTaskData implements ProsessTaskInfo {
 
     @Override
     public UUID getBehandlingUuid() {
-        var uuidString = getPropertyValue(CommonTaskProperties.BEHANDLING_UUID);
-        return uuidString != null ? UUID.fromString(uuidString) : null;
+        return Optional.ofNullable(getPropertyValue(CommonTaskProperties.BEHANDLING_UUID)).map(UUID::fromString).orElse(null);
     }
 
-    protected void setBehandlingUUid(UUID uuid) {
+    public void setBehandlingUUid(UUID uuid) {
         setProperty(CommonTaskProperties.BEHANDLING_UUID, uuid.toString());
     }
 
@@ -295,7 +306,7 @@ public class ProsessTaskData implements ProsessTaskInfo {
     @Deprecated(forRemoval = true)
     @Override
     public Long getFagsakId() {
-        return getPropertyValue(CommonTaskProperties.FAGSAK_ID) != null ? Long.valueOf(getPropertyValue(CommonTaskProperties.FAGSAK_ID)) : null;
+        return Optional.ofNullable(getPropertyValue(FAGSAK_ID)).map(Long::valueOf).orElse(null);
     }
 
     /**
@@ -303,7 +314,7 @@ public class ProsessTaskData implements ProsessTaskInfo {
      */
     @Deprecated(forRemoval = true)
     public void setFagsakId(Long id) {
-        setProperty(CommonTaskProperties.FAGSAK_ID, id.toString());
+        setProperty(FAGSAK_ID, id.toString());
     }
 
     @Override
@@ -323,19 +334,10 @@ public class ProsessTaskData implements ProsessTaskInfo {
      * behandlingId angitt behandlingId definert av fagsystem (kan være Long, UUID, etc)
      */
 
-    @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses - PTv2
-    public void setBehandling(Long fagsakId, Long behandlingId) {
-        Objects.requireNonNull(fagsakId, CommonTaskProperties.FAGSAK_ID);
-        Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
-
-        setFagsakId(fagsakId);
-        setBehandlingId(behandlingId.toString());
-    }
-
-    @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses - PTv2
+    // @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses før fjerning
     public void setBehandling(String saksnummer, Long fagsakId, Long behandlingId) {
         Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);
-        Objects.requireNonNull(fagsakId, CommonTaskProperties.FAGSAK_ID);
+        Objects.requireNonNull(fagsakId, FAGSAK_ID);
         Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
 
         setSaksnummer(saksnummer);
@@ -343,57 +345,10 @@ public class ProsessTaskData implements ProsessTaskInfo {
         setBehandlingId(behandlingId.toString());
     }
 
-    @Deprecated(forRemoval = true) // Impending removal next release
-    public void setBehandling(Long fagsakId, Long behandlingId, String aktørId) {
-        Objects.requireNonNull(fagsakId, CommonTaskProperties.FAGSAK_ID);
-        Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
-        Objects.requireNonNull(aktørId, CommonTaskProperties.AKTØR_ID);
-
-        setFagsakId(fagsakId);
-        setBehandlingId(behandlingId.toString());
-        setAktørId(aktørId);
-    }
-
-    @Deprecated(forRemoval = true) // Impending removal next release
-    public void setBehandling(String saksnummer, String behandlingId) {
-        Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);
-        Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
-
-        setSaksnummer(saksnummer);
-        setBehandlingId(behandlingId);
-    }
-
-    /**
-     * Convenience API - Angi (optional) hvilken behandling/sak denne prosesstasken kjøres for.
-     *
-     * @param saksnummer offisielt saksnummer
-     * @param behandlingId angitt behandlingId definert av fagsystem (kan være Long, UUID, etc)
-     * @param aktørId angitt AktørId gyldig i AktørRegisteret.
-     */
-    @Deprecated(forRemoval = true) // Impending removal next release
-    public void setBehandling(String saksnummer, String behandlingId, String aktørId) {
-        Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);
-        Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
-        Objects.requireNonNull(aktørId, CommonTaskProperties.AKTØR_ID);
-
-        setSaksnummer(saksnummer);
-        setBehandlingId(behandlingId);
-        setAktørId(aktørId);
-    }
-
-    @Deprecated(forRemoval = true) // Impending removal next release
-    public void setFagsak(Long fagsakId, String aktørId) {
-        Objects.requireNonNull(fagsakId, CommonTaskProperties.FAGSAK_ID);
-        Objects.requireNonNull(aktørId, CommonTaskProperties.AKTØR_ID);
-
-        setFagsakId(fagsakId);
-        setAktørId(aktørId);
-    }
-
-    @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses - PTv2
+    // @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses før fjerning
     public void setFagsak(String saksnummer, Long fagsakId) {
         Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);
-        Objects.requireNonNull(fagsakId, CommonTaskProperties.FAGSAK_ID);
+        Objects.requireNonNull(fagsakId, FAGSAK_ID);
 
         setSaksnummer(saksnummer);
         setFagsakId(fagsakId);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
@@ -345,6 +345,18 @@ public class ProsessTaskData implements ProsessTaskInfo {
         setBehandlingId(behandlingId.toString());
     }
 
+    public void setBehandling(String saksnummer, Long fagsakId, UUID behandlingUuid, Long behandlingId) {
+        Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);
+        Objects.requireNonNull(fagsakId, FAGSAK_ID);
+        Objects.requireNonNull(behandlingId, CommonTaskProperties.BEHANDLING_ID);
+        Objects.requireNonNull(behandlingUuid, CommonTaskProperties.BEHANDLING_UUID);
+
+        setSaksnummer(saksnummer);
+        setFagsakId(fagsakId);
+        setBehandlingUUid(behandlingUuid);
+        setBehandlingId(behandlingId.toString());
+    }
+
     // @Deprecated(forRemoval = true) // Fagsakprosesstask må fikses før fjerning
     public void setFagsak(String saksnummer, Long fagsakId) {
         Objects.requireNonNull(saksnummer, CommonTaskProperties.SAKSNUMMER);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskData.java
@@ -53,6 +53,7 @@ public class ProsessTaskData implements ProsessTaskInfo {
 
     ProsessTaskData(TaskType taskType) {
         this.taskType = taskType;
+        Optional.ofNullable(MDC.get(CallId.CALL_ID)).filter(c -> !c.isEmpty()).ifPresent(this::setCallId);
     }
 
     public static ProsessTaskData forProsessTask(Class<? extends ProsessTaskHandler> clazz) {
@@ -400,10 +401,16 @@ public class ProsessTaskData implements ProsessTaskInfo {
         setStatus(ProsessTaskStatus.VENTER_SVAR);
     }
 
+    // Sett til null for å fjerne.
     public void setCallId(String callId) {
         setProperty(CallId.CALL_ID, callId);
     }
 
+    public boolean harCallId() {
+        return Optional.ofNullable(getPropertyValue(CallId.CALL_ID)).filter(c -> !c.isEmpty()).isPresent();
+    }
+
+    @Deprecated(forRemoval = true) // Default oppførsel
     public void setCallIdFraEksisterende() {
         setCallId(MDC.get(CallId.CALL_ID));
     }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskGruppe.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskGruppe.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import org.slf4j.MDC;
 
@@ -69,22 +70,22 @@ public class ProsessTaskGruppe {
 
     public static record Entry(String sekvens, ProsessTaskData task) {}
 
-    @Deprecated(forRemoval = true) // Immediate next patch
-    public void setBehandling(Long fagsakId, Long behandlingId, String aktørId) {
-        this.getTasks().forEach(e -> e.task().setBehandling(fagsakId, behandlingId, aktørId));
-    }
-
-    @Deprecated(forRemoval = true) // Immediate next patch
-    public void setBehandling(Long fagsakId, Long behandlingId) {
-        this.getTasks().forEach(e -> e.task().setBehandling(fagsakId, behandlingId));
-    }
-
+    // FagsakId med inntil videre pga FagsakProsessTask i enkelte apps
     public void setBehandling(String saksnummer, Long fagsakId, Long behandlingId) {
         this.getTasks().forEach(e -> e.task().setBehandling(saksnummer, fagsakId, behandlingId));
     }
 
     public void setFagsak(String saksnummer, Long fagsakId) {
         this.getTasks().forEach(e -> e.task().setFagsak(saksnummer, fagsakId));
+    }
+
+    // For bruk der FagsakProsessTask ikke er aktuell
+    public void setBehandlingUuid(UUID behandlingUuid) {
+        this.getTasks().forEach(e -> e.task().setBehandlingUUid(behandlingUuid));
+    }
+
+    public void setSaksnummer(String saksnummer) {
+        this.getTasks().forEach(e -> e.task().setSaksnummer(saksnummer));
     }
 
     public void setCallId(String callId) {

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskGruppe.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskGruppe.java
@@ -75,6 +75,10 @@ public class ProsessTaskGruppe {
         this.getTasks().forEach(e -> e.task().setBehandling(saksnummer, fagsakId, behandlingId));
     }
 
+    public void setBehandling(String saksnummer, Long fagsakId, UUID behandlingUuid, Long behandlingId) {
+        this.getTasks().forEach(e -> e.task().setBehandling(saksnummer, fagsakId, behandlingUuid, behandlingId));
+    }
+
     public void setFagsak(String saksnummer, Long fagsakId) {
         this.getTasks().forEach(e -> e.task().setFagsak(saksnummer, fagsakId));
     }
@@ -92,6 +96,10 @@ public class ProsessTaskGruppe {
         setProperty(CallId.CALL_ID, callId);
     }
 
+    public boolean harCallId() {
+        return tasks.isEmpty() || tasks.stream().map(Entry::task).allMatch(ProsessTaskData::harCallId);
+    }
+
     public void setProperty(String key, String value) {
         props.put(key, value);
         for (Entry pt : tasks) {
@@ -100,6 +108,7 @@ public class ProsessTaskGruppe {
         }
     }
 
+    @Deprecated(forRemoval = true) // Default oppførsel
     public void setCallIdFraEksisterende() {
         setCallId(MDC.get(CallId.CALL_ID));
     }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskInfo.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/api/ProsessTaskInfo.java
@@ -68,8 +68,12 @@ public interface ProsessTaskInfo {
     Long getFagsakId();
 
     String getSaksnummer();
-    
+
     String getBehandlingId();
 
     UUID getBehandlingUuid();
+
+    default Long getBehandlingIdAsLong() {
+        return Optional.ofNullable(getBehandlingId()).map(Long::valueOf).orElse(null);
+    }
 }

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepository.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepository.java
@@ -6,10 +6,13 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 
 import org.hibernate.jpa.HibernateHints;
 import org.hibernate.query.NativeQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,6 +21,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.felles.prosesstask.api.CallId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
@@ -28,6 +32,8 @@ import no.nav.vedtak.felles.prosesstask.impl.util.DatabaseUtil;
  */
 @ApplicationScoped
 public class ProsessTaskRepository {
+
+    static final Logger LOG = LoggerFactory.getLogger(ProsessTaskRepository.class);
 
     private EntityManager entityManager;
     private ProsessTaskEventPubliserer eventPubliserer;
@@ -136,6 +142,10 @@ public class ProsessTaskRepository {
      * Lagre og returner id.
      */
     protected Long doLagreTask(ProsessTaskData task) {
+        var callId = Optional.ofNullable(task.getPropertyValue(CallId.CALL_ID)).filter(c -> !c.isEmpty());
+        if (callId.isEmpty()) {
+            LOG.info("Lagrer prosesstask uten callId - taskType {}", task.taskType().value());
+        }
         ProsessTaskEntitet pte;
         if (task.getId() != null) {
             trackTaskLineage("latest", task);

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerGenerateRunnableTasks.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerGenerateRunnableTasks.java
@@ -5,11 +5,10 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
-import jakarta.enterprise.inject.spi.CDI;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.enterprise.inject.spi.CDI;
 import no.nav.vedtak.felles.prosesstask.api.CallId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskDispatcher;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
@@ -17,7 +16,7 @@ import no.nav.vedtak.felles.prosesstask.impl.TaskManager.ReadTaskFunksjon;
 
 /** Poller for tilgjengelige tasks og omsetter disse til Runnable som kan kjøres på andre tråder. */
 public class TaskManagerGenerateRunnableTasks {
-    static final Logger log = LoggerFactory.getLogger(TaskManagerGenerateRunnableTasks.class);
+    static final Logger LOG = LoggerFactory.getLogger(TaskManagerGenerateRunnableTasks.class);
     static final CDI<Object> CURRENT = CDI.current();
 
     private final BiFunction<Integer, ReadTaskFunksjon, List<IdentRunnable>> availableTasksFunc;

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRunnableTask.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRunnableTask.java
@@ -3,10 +3,9 @@ package no.nav.vedtak.felles.prosesstask.impl;
 import java.time.LocalDateTime;
 import java.util.function.Consumer;
 
-import jakarta.persistence.PersistenceException;
-
 import org.slf4j.MDC;
 
+import jakarta.persistence.PersistenceException;
 import no.nav.vedtak.felles.prosesstask.api.CallId;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 
@@ -62,7 +61,7 @@ class TaskManagerRunnableTask implements Runnable {
                 errorTask.doRun(taskInfo, fatal);
             } catch (Throwable t) {
                 // logg at vi ikke klarte å registrer feilen i db
-                TaskManagerGenerateRunnableTasks.log.error(
+                TaskManagerGenerateRunnableTasks.LOG.error(
                         "PT-415565 Kunne ikke registrere feil på task pga uventet feil ved oppdatering av status/feil, id={}, taskName={}.", taskInfo.getId(), taskInfo.getTaskType(), t);
             } finally {
                 clearLogContext();
@@ -71,7 +70,7 @@ class TaskManagerRunnableTask implements Runnable {
         };
 
         // logg at vi kommer til å skrive dette i ny transaksjon pga fatal feil.
-        TaskManagerGenerateRunnableTasks.log.warn("PT-876628 Kritisk database feil som gir rollback. Kan ikke prosessere task, vil logge til db i ny transaksjon, id={}, taskName={} pga uventet feil.",
+        TaskManagerGenerateRunnableTasks.LOG.warn("PT-876628 Kritisk database feil som gir rollback. Kan ikke prosessere task, vil logge til db i ny transaksjon, id={}, taskName={} pga uventet feil.",
                 taskInfo.getId(), taskInfo.getTaskType(), fatal);
 
 


### PR DESCRIPTION
Har satt saksnummer de fleste steder i de fleste apps. 
Risk og Formidling kan godt få med et saksnummer i requester slik at det kan settes enda flere steder.

Må beholde fagsakId inntil videre pga FagsakProsessTask i fpsak og fptilbake.
Bruker behandlingId inntil videre i samme apps - mens behandlingUuid solo kan eksponeres og brukes i andre apps.