### PR TITLE
Bytt database for å sikre migrering

### DIFF
--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/JpaExtension.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/JpaExtension.java
@@ -1,12 +1,9 @@
 package no.nav.vedtak.felles.prosesstask;
 
 import jakarta.persistence.EntityManager;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.felles.jpa.TransactionHandler;
 import no.nav.vedtak.felles.jpa.TransactionHandler.Work;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareExtension;
-import org.testcontainers.oracle.OracleContainer;
-import org.testcontainers.utility.DockerImageName;
 
 class JpaExtension extends EntityManagerAwareExtension {
 

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHendelseMottakImplTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHendelseMottakImplTest.java
@@ -21,7 +21,7 @@ import org.mockito.quality.Strictness;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;
-import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -29,7 +29,7 @@ import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 import no.nav.vedtak.log.util.MemoryAppender;
 
 @ExtendWith(MockitoExtension.class)
-@ExtendWith(JpaPostgresTestcontainerExtension.class)
+@ExtendWith(JpaOracleTestcontainerExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ProsessTaskHendelseMottakImplTest extends EntityManagerAwareTest {
 

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImplTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskRepositoryImplTest.java
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 
-import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.CommonTaskProperties;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
-@ExtendWith(JpaOracleTestcontainerExtension.class)
+@ExtendWith(JpaPostgresTestcontainerExtension.class)
 class ProsessTaskRepositoryImplTest extends EntityManagerAwareTest {
 
     private static final TaskType TASK_TYPE = new TaskType("hello.world");


### PR DESCRIPTION
Noe mystisk med testmigrering og rekkefølge av testkjøring i GHA. Bytter om på database om for å se effekt