### PR TITLE
Kjører alle tester med postgres pga GHA-ustabilitet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<sonar.projectName>fp-prosesstask</sonar.projectName>
 		<sonar.projectKey>navikt_fp-prosesstask</sonar.projectKey>
 
-		<felles.version>7.4.9</felles.version>
+		<felles.version>7.4.11</felles.version>
 
         <jakarta.jakartaee-bom.version>10.0.0</jakarta.jakartaee-bom.version>
         <hibernate-core.version>6.6.9.Final</hibernate-core.version>
@@ -368,7 +368,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>flatten-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>1.7.0</version>
                     <configuration>
                         <flattenedPomFilename>.flattened</flattenedPomFilename>
                         <flattenMode>bom</flattenMode>

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/OpprettProsessTaskITTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/OpprettProsessTaskITTest.java
@@ -8,14 +8,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
-@ExtendWith(JpaOracleTestcontainerExtension.class)
+@ExtendWith(JpaPostgresTestcontainerExtension.class)
 class OpprettProsessTaskITTest extends EntityManagerAwareTest {
 
     private ProsessTaskRepository repo;

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHendelseMottakImplTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/ProsessTaskHendelseMottakImplTest.java
@@ -21,7 +21,7 @@ import org.mockito.quality.Strictness;
 import org.slf4j.LoggerFactory;
 
 import ch.qos.logback.classic.Logger;
-import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -29,7 +29,7 @@ import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 import no.nav.vedtak.log.util.MemoryAppender;
 
 @ExtendWith(MockitoExtension.class)
-@ExtendWith(JpaOracleTestcontainerExtension.class)
+@ExtendWith(JpaPostgresTestcontainerExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
 class ProsessTaskHendelseMottakImplTest extends EntityManagerAwareTest {
 

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerGenerateRunnableTasksITTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerGenerateRunnableTasksITTest.java
@@ -11,12 +11,12 @@ import org.mockito.Mockito;
 
 import ch.qos.logback.classic.Level;
 import jakarta.persistence.PersistenceException;
-import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
-@ExtendWith(JpaOracleTestcontainerExtension.class)
+@ExtendWith(JpaPostgresTestcontainerExtension.class)
 class TaskManagerGenerateRunnableTasksITTest extends EntityManagerAwareTest {
 
     private static final MemoryAppender LOG_SNIFFER = MemoryAppender.sniff(TaskManagerGenerateRunnableTasks.class);

--- a/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeITTest.java
+++ b/task/src/test/java/no/nav/vedtak/felles/prosesstask/impl/TaskManagerRekkefølgeITTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import no.nav.vedtak.felles.prosesstask.JpaOracleTestcontainerExtension;
+import no.nav.vedtak.felles.prosesstask.JpaPostgresTestcontainerExtension;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
@@ -19,7 +19,7 @@ import no.nav.vedtak.felles.prosesstask.api.TaskMonitor;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
 import no.nav.vedtak.felles.testutilities.db.EntityManagerAwareTest;
 
-@ExtendWith(JpaOracleTestcontainerExtension.class)
+@ExtendWith(JpaPostgresTestcontainerExtension.class)
 class TaskManagerRekkefølgeITTest extends EntityManagerAwareTest {
 
     private ProsessTaskRepository repo;


### PR DESCRIPTION
Litt for mye variasjon om tester får feil "sequence does not exist" i GH.
Beholder begge testalternativ for lokal testing og validering 