### PR TITLE
chore: Gjør optimisticlockexception retryable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <jakarta.jakartaee-bom.version>10.0.0</jakarta.jakartaee-bom.version>
         <hibernate-core.version>6.6.13.Final</hibernate-core.version>
         <jetty.version>12.0.20</jetty.version>
-        <flyway.version>11.8.1</flyway.version>
+        <flyway.version>11.8.0</flyway.version>
 
         <mockito.version>5.17.0</mockito.version>
     </properties>

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/BasicCdiProsessTaskDispatcher.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/BasicCdiProsessTaskDispatcher.java
@@ -6,6 +6,7 @@ import java.sql.SQLTransientException;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import jakarta.persistence.OptimisticLockException;
 import jakarta.persistence.QueryTimeoutException;
 
 import org.hibernate.exception.JDBCConnectionException;
@@ -25,6 +26,7 @@ public class BasicCdiProsessTaskDispatcher implements ProsessTaskDispatcher {
      */
     private static final Set<Class<?>> DEFAULT_FEILHÅNDTERING_EXCEPTIONS = Set.of(
             JDBCConnectionException.class,
+            OptimisticLockException.class,
             QueryTimeoutException.class,
             SQLTransientException.class,
             SQLNonTransientConnectionException.class,

--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
@@ -463,14 +463,14 @@ public class TaskManager implements Controllable {
 
     private static int getSystemPropertyWithLowerBoundry(String key, int defaultValue, int lowerBoundry) {
         final var property = Optional.ofNullable(getenv(key.toUpperCase().replace(".", "_")))
-            .orElse(System.getProperty(key, String.valueOf(defaultValue)));
+            .orElseGet(() -> System.getProperty(key, String.valueOf(defaultValue)));
         final var systemPropertyValue = Integer.parseInt(property);
         return Math.max(systemPropertyValue, lowerBoundry);
     }
 
     private static long getSystemPropertyWithLowerBoundry(String key, long defaultValue, long lowerBoundry) {
         final var property = Optional.ofNullable(getenv(key.toUpperCase().replace(".", "_")))
-            .orElse(System.getProperty(key, String.valueOf(defaultValue)));
+            .orElseGet(() -> System.getProperty(key, String.valueOf(defaultValue)));
         final var systemPropertyValue = Long.parseLong(property);
         return Math.max(systemPropertyValue, lowerBoundry);
     }


### PR DESCRIPTION
For å å håndtere tilfelle i LOS, autotest, mv.
@mrsladek du har merket flyway 10.18.1 som buggy i fp-bom, så reverter her. 
La også inn orElseGet siden det er kall - orElse vil alltid kalle metoden, orElseGet kaller bare når forrige er tom