### PR TITLE
Copilot: Oppdater med ref til fp-context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,11 +24,11 @@ of pods. Used by all Team Foreldrepenger backend apps for background work.
 
 ## Module layout
 
-| Module | Purpose |
-|--------|---------|
-| `task` | Core task framework, polling, dispatch |
+| Module | Purpose                                       |
+|--------|-----------------------------------------------|
+| `task` | Core task framework, polling, dispatch        |
 | `rest` | REST endpoints for monitoring/admin |
-| `kontekst` | Context propagation across task boundaries |
+| `kontekst` | Tie-in with fp-felles / log + kontekst        |
 
 ## Usage patterns (in consumer apps)
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# fp-prosesstask
+
+Framework for persistent, fault-tolerant async processing across a cluster
+of pods. Used by all Team Foreldrepenger backend apps for background work.
+
+## Context
+
+- [fp-context](https://github.com/navikt/fp-context) — team domain,
+  architecture, conventions. Source of truth.
+- Consumer view of the patterns this enables:
+  [`architecture/team-libraries.md`](https://github.com/navikt/fp-context/blob/main/architecture/team-libraries.md).
+- Copilot Space: navikt / **TeamForeldrepenger**.
+
+## What it provides
+
+| Capability | Description |
+|------------|-------------|
+| Persistent tasks | Tasks stored in DB; survive restarts |
+| Distributed execution | Pollers across pods pick up ready tasks |
+| Sequential / parallel | Tasks can depend on other tasks |
+| Retry semantics | Configurable per-task error handling |
+| Scheduled jobs | Cron-like recurring tasks |
+| Fail-fast coding | Throw on bad data; framework persists for retry after fix |
+
+## Module layout
+
+| Module | Purpose |
+|--------|---------|
+| `task` | Core task framework, polling, dispatch |
+| `rest` | REST endpoints for monitoring/admin |
+| `kontekst` | Context propagation across task boundaries |
+
+## Usage patterns (in consumer apps)
+
+| Pattern | Use case |
+|---------|----------|
+| Outbox | Calls to REST/Kafka/MQ outside DB transaction; target must be idempotent |
+| Inbox | Take ownership of inbound messages before further processing |
+| Saga | Orchestrated multi-step transactions |
+| Scheduled | Cron-like recurring jobs |
+
+## When changing this repo
+
+- Public task API changes are breaking — bump major, coordinate with consumers
+- DB schema changes need migration scripts compatible with all consumer apps
+- Polling/dispatch logic affects throughput everywhere — benchmark
+- Preserve fail-fast + retry semantics; consumers depend on it
+
+## Release
+
+SemVer; release artifact published to consumer repos via fp-bom + Dependabot.
+
+## Tech
+
+Java 25, Jakarta EE 10, JPA/Hibernate, Maven. Versions pinned via `fp-bom`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -52,4 +52,4 @@ SemVer; release artifact published to consumer repos via fp-bom + Dependabot.
 
 ## Tech
 
-Java 25, Jakarta EE 10, JPA/Hibernate, Maven. Versions pinned via `fp-bom`.
+Java 25, Jakarta EE 11, JPA/Hibernate, Maven. Versions pinned via `fp-bom`.


### PR DESCRIPTION
Add Copilot instructions referencing [fp-context](https://github.com/navikt/fp-context) (incl. the new `architecture/team-libraries.md`) and the **TeamForeldrepenger** Copilot Space.

Focuses on what's needed to maintain this library: internal structure, conventions, consumer-impact notes for changes.

Part of an ongoing effort to keep per-repo Copilot files token-efficient and free of duplication across the team's 40+ repos.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>