### PR TITLE
chore: eksplisitt validering av ProsessTaskOpprettInputDto.taskParametre key/values

### DIFF
--- a/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjeneste.java
+++ b/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjeneste.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
@@ -85,7 +86,9 @@ public class ProsessTaskApplikasjonTjeneste {
     public ProsessTaskDataDto opprettTask(ProsessTaskOpprettInputDto inputDto) {
         var sanitizedTaskType = inputDto.getTaskType().replace("\n", "").replace("\r", "").trim();
         var taskData = ProsessTaskData.forTaskType(new TaskType(sanitizedTaskType));
-        taskData.setProperties(inputDto.getTaskParametre());
+        var properties = new Properties();
+        properties.putAll(inputDto.getTaskParametre());
+        taskData.setProperties(properties);
         prosessTaskTjeneste.lagreValidert(taskData);
 
         return ProsessTaskDataKonverter.tilProsessTaskDataDto(taskData);

--- a/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
+++ b/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
@@ -1,12 +1,15 @@
 package no.nav.vedtak.felles.prosesstask.rest.dto;
 
-import java.util.Properties;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -15,16 +18,22 @@ import jakarta.validation.constraints.Size;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public class ProsessTaskOpprettInputDto {
 
+    private static final String PARAMETRE_PATTERN = "^[\\p{Alnum}æøåÆØÅ_.\\-]*$";
+
     @JsonProperty(value="taskType", required=true)
     @NotNull
     @Size(min = 1, max = 100)
-    @Pattern(regexp = "^[\\p{Alnum}æøåÆØÅ_.\\-]*$")
+    @Pattern(regexp = PARAMETRE_PATTERN)
     private String taskType;
 
-    @JsonProperty(value="taskParametre", required = true)
+    @JsonProperty(value = "taskParametre", required = true)
     @NotNull
     @Size(max = 100)
-    private Properties taskParametre = new Properties();
+    @Valid
+    private Map<
+        @NotBlank @Size(max = 100) @Pattern(regexp = PARAMETRE_PATTERN) String,
+        @NotNull @Size(max = 1000) @Pattern(regexp = PARAMETRE_PATTERN) String
+        > taskParametre = new HashMap<>();
 
     public String getTaskType() {
         return taskType;
@@ -34,11 +43,11 @@ public class ProsessTaskOpprettInputDto {
         this.taskType = taskType;
     }
 
-    public Properties getTaskParametre() {
+    public Map<String, String> getTaskParametre() {
         return taskParametre;
     }
 
-    public void setTaskParametre(Properties taskParametre) {
+    public void setTaskParametre(Map<String, String> taskParametre) {
         this.taskParametre = taskParametre;
     }
 

--- a/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
+++ b/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -25,7 +24,6 @@ public class ProsessTaskOpprettInputDto {
     @JsonProperty(value="taskParametre", required = true)
     @NotNull
     @Size(max = 100)
-    @Valid
     private Properties taskParametre = new Properties();
 
     public String getTaskType() {

--- a/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
+++ b/rest/src/main/java/no/nav/vedtak/felles/prosesstask/rest/dto/ProsessTaskOpprettInputDto.java
@@ -29,10 +29,9 @@ public class ProsessTaskOpprettInputDto {
     @JsonProperty(value = "taskParametre", required = true)
     @NotNull
     @Size(max = 100)
-    @Valid
     private Map<
-        @NotBlank @Size(max = 100) @Pattern(regexp = PARAMETRE_PATTERN) String,
-        @NotNull @Size(max = 1000) @Pattern(regexp = PARAMETRE_PATTERN) String
+        @NotBlank @Valid @Size(max = 100) @Pattern(regexp = PARAMETRE_PATTERN) String,
+        @NotNull @Valid @Size(max = 1000) @Pattern(regexp = PARAMETRE_PATTERN) String
         > taskParametre = new HashMap<>();
 
     public String getTaskType() {

--- a/rest/src/test/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjenesteTest.java
+++ b/rest/src/test/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjenesteTest.java
@@ -140,7 +140,7 @@ class ProsessTaskApplikasjonTjenesteTest {
     void opprett_prosess_task() {
         var input = new ProsessTaskOpprettInputDto();
         input.setTaskType(TASK_TYPE_NAME);
-        input.setTaskParametre(new Properties());
+        input.setTaskParametre(Map.of());
 
         var prosessTaskDataDto = prosessTaskApplikasjonTjeneste.opprettTask(input);
 

--- a/rest/src/test/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjenesteTest.java
+++ b/rest/src/test/java/no/nav/vedtak/felles/prosesstask/rest/app/ProsessTaskApplikasjonTjenesteTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;


### PR DESCRIPTION
Ved bruk av swagger for opprettelse av prosesstask logges det warning om deprecated valid-annotasjon på containers. ProsessTaskOpprettInputDto.taskParametre er av typen Properties. Denne PR bytter ut direkte bruk av Properties i DTO med Map med aktuell validering. Gjenbruker regex som brukes for validering av taskType.

Se ellers https://nav-it.slack.com/archives/CEKQHNLLU/p1779802023477589