### PR TITLE
Chore: fjerne ubrukt (og usunn) getCurrentTask

### DIFF
--- a/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
+++ b/task/src/main/java/no/nav/vedtak/felles/prosesstask/impl/TaskManager.java
@@ -110,11 +110,6 @@ public class TaskManager implements Controllable {
     private final AtomicReference<LocalDateTime> pollerRoundNoneFoundSince = new AtomicReference<>(LocalDateTime.now());
     private final AtomicReference<LocalDateTime> pollerRoundNoneLastReported = new AtomicReference<>(LocalDateTime.now());
 
-    /**
-     * trenger ikke ha denne som static siden TaskManager er ApplicationScoped.
-     */
-    private final ThreadLocal<ProsessTaskData> currentTask = new ThreadLocal<>();
-
     static final String TASK_PROP = "prosess_task";
     static final String TASK_ID_PROP = "prosess_task_id";
 
@@ -142,12 +137,7 @@ public class TaskManager implements Controllable {
 
                 @Override
                 public void dispatch(ProsessTaskData task) throws Exception {
-                    try {
-                        currentTask.set(task);
-                        delegate.dispatch(task);
-                    } finally {
-                        currentTask.remove();
-                    }
+                    delegate.dispatch(task);
                 }
 
                 @Override
@@ -231,10 +221,6 @@ public class TaskManager implements Controllable {
             runTaskService.stop();
             runTaskService = null;
         }
-    }
-
-    public ProsessTaskData getCurrentTask() {
-        return currentTask.get();
     }
 
     synchronized void startPollerThread() {


### PR DESCRIPTION
Denne currentTask-saken er ikke brukt utenfor TaskManager.
Det virker litt usunt å ha den ettersom man må vøre innenfor samme tråd - dvs reachable fra selve den kjørende tasken.
Vi har klart oss så langt med at tasks ikke er TaskManager-aware og bør fortsette med det.
Skal den gjeninnføres, så bruk ScopedValue.where(CURRENT, task).call(...) - ThreadLocal er på vei ut.